### PR TITLE
feat: add return_type csv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,7 @@ repos:
     additional_dependencies:
     - orjson # Ref: https://github.com/python/mypy/blob/v1.13.0/CHANGELOG.md#improved-performance
     - httpx>=0.27
+    - pandas-stubs>=2.2
     - pytest>=8.2
     - respx>=0.21
     - typer>=0.12

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Repository(re3data_org_identifier='r3d100010468', repository_name=RepositoryName
     - dataclass (default): Returns a Python dataclass object, allowing convenient access to the element of the re3data
         schema
     - response: Returns a Python object representing the API response
-    - original XML: Returns the raw XML response from the API
-    - JSON: Returns a JSON representation of the API response
+    - original XML (str): Returns the raw XML response from the API
+    - JSON (str): Returns a JSON representation of the API response
     - dictionary: Returns a dictionary representation of the API response
+    - csv (str): Returns a CSV representation of the API response
+    - dataframe: Returns a pandas.DataFrame representation of the API response
 
 ## Requirements
 
@@ -61,6 +63,8 @@ Repository(re3data_org_identifier='r3d100010468', repository_name=RepositoryName
     schemas, simplifies processing of API responses.
 - **Optional CLI**: [typer](https://github.com/tiangolo/typer), a popular library for building command-line interfaces,
     powers the user-friendly interface.
+- **Optional DataFrame/CSV**: [pandas](https://github.com/pandas-dev/pandas), a powerful and flexible data analysis
+    library, enables generation of DataFrames and CSV files from parsed XML responses.
 
 ## Installation
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -129,6 +129,14 @@ Install with `python -m pip install "python-re3data[cli]"`.
 | ------------------------------------------ | ------- | ------------------------------------------------------------------------------------------- |
 | [typer](https://github.com/tiangolo/typer) | >= 0.12 | A popular library for building command-line interfaces, powers the user-friendly interface. |
 
+#### CSV
+
+Install with `python -m pip install "python-re3data[csv]"`.
+
+| Package                                        | Version | Description                                                                                                              |
+| ---------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| [pandas](https://github.com/pandas-dev/pandas) | >= 2.0  | A powerful and flexible data analysis library, enables generation of DataFrames and CSV files from parsed XML responses. |
+
 <!---
 This installation guide is adapted from these sources:
 - "pandas" Installation, https://pandas.pydata.org/docs/getting_started/install.html (BSD-3-Clause license)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,12 @@ dependencies = [
 optional-dependencies.cli = [
   "typer>=0.12",
 ]
+optional-dependencies.csv = [
+  "pandas>=2",
+]
 optional-dependencies.dev = [
   "pre-commit-uv~=4.1",
-  "python-re3data[cli]",
+  "python-re3data[cli,csv]",
 ]
 optional-dependencies.docs = [
   "mike~=2.1",

--- a/src/re3data/_client/_async.py
+++ b/src/re3data/_client/_async.py
@@ -22,8 +22,9 @@ from re3data._exceptions import RepositoryNotFoundError
 from re3data._response import Response, _build_response
 
 if TYPE_CHECKING:
-    from re3data._resources import Repository, RepositorySummary
+    from pandas import DataFrame
 
+    from re3data._resources import Repository, RepositorySummary
 logger = logging.getLogger(__name__)
 
 
@@ -59,7 +60,7 @@ class AsyncRepositoryManager:
         query: str | None = None,
         return_type: ReturnType = ReturnType.DATACLASS,
         count: bool = False,
-    ) -> list[RepositorySummary] | Response | dict[str, Any] | str | int:
+    ) -> list[RepositorySummary] | Response | dict[str, Any] | DataFrame | str | int:
         """List the metadata of all repositories in the re3data API.
 
         Args:
@@ -83,7 +84,7 @@ class AsyncRepositoryManager:
 
     async def get(
         self, repository_id: str, return_type: ReturnType = ReturnType.DATACLASS
-    ) -> Repository | Response | dict[str, Any] | str:
+    ) -> Repository | Response | dict[str, Any] | DataFrame | str:
         """Get the metadata of a specific repository.
 
         Args:

--- a/src/re3data/_client/_sync.py
+++ b/src/re3data/_client/_sync.py
@@ -24,8 +24,9 @@ from re3data._exceptions import RepositoryNotFoundError
 from re3data._response import Response, _build_response
 
 if TYPE_CHECKING:
-    from re3data._resources import Repository, RepositorySummary
+    from pandas import DataFrame
 
+    from re3data._resources import Repository, RepositorySummary
 logger = logging.getLogger(__name__)
 
 
@@ -61,7 +62,7 @@ class RepositoryManager:
         query: str | None = None,
         return_type: ReturnType = ReturnType.DATACLASS,
         count: bool = False,
-    ) -> list[RepositorySummary] | Response | dict[str, Any] | str | int:
+    ) -> list[RepositorySummary] | Response | dict[str, Any] | DataFrame | str | int:
         """List the metadata of all repositories in the re3data API.
 
         Args:
@@ -85,7 +86,7 @@ class RepositoryManager:
 
     def get(
         self, repository_id: str, return_type: ReturnType = ReturnType.DATACLASS
-    ) -> Repository | Response | dict[str, Any] | str:
+    ) -> Repository | Response | dict[str, Any] | DataFrame | str:
         """Get the metadata of a specific repository.
 
         Args:

--- a/src/re3data/_serializer.py
+++ b/src/re3data/_serializer.py
@@ -2,24 +2,41 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""The _serializer module offers functions for converting parsed data into dictionaries or JSON strings.
+"""The _serializer module offers functions for converting parsed data into various return types.
 
-This module provides functions to serialize various types of data into dictionaries or JSON strings.
+This module provides functions to serialize various types of data, e.g. into dictionaries or JSON strings.
 The serialized data can be used for further processing or storage.
 
 Functions:
     _to_dict: Serialize parsed data into a dictionary.
     _to_json: Serialize parsed data into a JSON string.
+    _to_dataframe: Serialize parsed data into a DataFrame.
+    _to_csv: Serialize parsed data into a CSV string.
 """
 
-from typing import Any
+from __future__ import annotations
+
+import logging
+import sys
+from typing import TYPE_CHECKING, Any
+
+try:
+    from pandas import json_normalize
+
+    PANDAS_INSTALLED = True
+except ImportError:
+    PANDAS_INSTALLED = False
 
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.serializers import DictEncoder, JsonSerializer
 from xsdata.formats.dataclass.serializers.config import SerializerConfig
 
-from re3data._resources import Repository, RepositorySummary
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
+    from re3data._resources import Repository, RepositorySummary
+
+logger = logging.getLogger(__name__)
 CONFIG = SerializerConfig(indent="  ")
 CONTEXT = XmlContext()
 
@@ -51,3 +68,35 @@ def _to_json(parsed: Repository | list[RepositorySummary]) -> str:
         A JSON representation of the input data.
     """
     return JSON_SERIALIZER.render(parsed)
+
+
+def _to_dataframe(parsed: Repository | list[RepositorySummary]) -> DataFrame:
+    """Serialize parsed data into a DataFrame.
+
+    Args:
+        parsed: The input data to be serialized. It can be either a single `Repository` object or a list of
+            `RepositorySummary` objects.
+
+    Returns:
+        A DataFrame representation of the input data.
+    """
+    if PANDAS_INSTALLED:
+        return json_normalize(_to_dict(parsed))
+    logger.error("`pandas` is missing. Please run 'pip install python-re3data[csv]'.")
+    sys.exit(1)
+
+
+def _to_csv(parsed: Repository | list[RepositorySummary]) -> str:
+    """Serialize parsed data into a CSV string.
+
+    Args:
+        parsed: The input data to be serialized. It can be either a single `Repository` object or a list of
+            `RepositorySummary` objects.
+
+    Returns:
+        A CSV string representation of the input data.
+    """
+    if PANDAS_INSTALLED:
+        return _to_dataframe(parsed).to_csv(index=False)
+    logger.error("`pandas` is missing. Please run 'pip install python-re3data[csv]'.")
+    sys.exit(1)

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 import pytest
+from pandas import DataFrame
 
 from re3data import RepositoryNotFoundError, Response, ReturnType
 from re3data._resources import Repository, RepositoryName, RepositorySummary
@@ -62,6 +63,21 @@ async def test_client_list_repositories_dict(async_client: AsyncClient, mock_rep
     repository = response[0]
     assert isinstance(repository, dict)
     assert repository["id"] == "r3d100010371"
+
+
+async def test_client_list_repositories_csv(async_client: AsyncClient, mock_repository_list_route: Route) -> None:
+    response = await async_client.repositories.list(return_type=ReturnType.CSV)
+    assert isinstance(response, str)
+    assert response.startswith("id,doi,name,")
+    assert "r3d100010371" in response
+    assert "https://doi.org/10.17616/R3P594" in response
+
+
+async def test_client_list_repositories_dataframe(async_client: AsyncClient, mock_repository_list_route: Route) -> None:
+    response = await async_client.repositories.list(return_type=ReturnType.DATAFRAME)
+    assert isinstance(response, DataFrame)
+    assert response.shape == (3, 5)
+    assert response["id"].loc[0] == "r3d100010371"
 
 
 async def test_client_list_repositories_response(async_client: AsyncClient, mock_repository_list_route: Route) -> None:
@@ -137,6 +153,24 @@ async def test_client_get_single_repository_dict(
     response = await async_client.repositories.get(zenodo_id, return_type=ReturnType.DICT)
     assert isinstance(response, dict)
     assert response["re3data.orgIdentifier"] == zenodo_id
+
+
+async def test_client_get_single_repository_csv(
+    async_client: AsyncClient, mock_repository_get_route: Route, zenodo_id: str
+) -> None:
+    response = await async_client.repositories.get(zenodo_id, return_type=ReturnType.CSV)
+    assert isinstance(response, str)
+    assert response.startswith("re3data.orgIdentifier,additionalName,repositoryURL,")
+    assert "r3d100010468" in response
+
+
+async def test_client_get_single_repository_dataframe(
+    async_client: AsyncClient, mock_repository_get_route: Route, zenodo_id: str
+) -> None:
+    response = await async_client.repositories.get(zenodo_id, return_type=ReturnType.DATAFRAME)
+    assert isinstance(response, DataFrame)
+    assert response.shape == (1, 43)
+    assert response["re3data.orgIdentifier"].loc[0] == "r3d100010468"
 
 
 async def test_client_get_single_repository_response(

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -97,18 +97,33 @@ def test_repository_list_json(mock_repository_list_route: Route) -> None:
     assert '"doi": "https://doi.org/10.17616/R3P594",' in result.output
 
 
-def test_repository_list_response(mock_repository_list_route: Route) -> None:
-    result = runner.invoke(app, ["repository", "list", "--return-type", "response"])
-    assert result.exit_code == 0
-    assert "Response" in result.output
-    assert "url=URL('https://www.re3data.org/api/beta/repositories')" in result.output
-
-
 def test_repository_list_dict(mock_repository_list_route: Route) -> None:
     result = runner.invoke(app, ["repository", "list", "--return-type", "dict"])
     assert result.exit_code == 0
     assert "'id': 'r3d100010371'," in result.output
     assert "'doi': 'https://doi.org/10.17616/R3P594'," in result.output
+
+
+def test_repository_list_csv(mock_repository_list_route: Route) -> None:
+    result = runner.invoke(app, ["repository", "list", "--return-type", "csv"])
+    assert result.exit_code == 0
+    assert "id,doi,name,link.href," in result.output
+    assert "https://doi.org/10.17616/R3P594" in result.output
+
+
+def test_repository_list_dataframe(mock_repository_list_route: Route) -> None:
+    result = runner.invoke(app, ["repository", "list", "--return-type", "dataframe"])
+    assert result.exit_code == 0
+    assert "id" in result.output
+    assert "r3d100010371" in result.output
+    assert "[3 rows x 5 columns]" in result.output
+
+
+def test_repository_list_response(mock_repository_list_route: Route) -> None:
+    result = runner.invoke(app, ["repository", "list", "--return-type", "response"])
+    assert result.exit_code == 0
+    assert "Response" in result.output
+    assert "url=URL('https://www.re3data.org/api/beta/repositories')" in result.output
 
 
 def test_repository_list_invalid_return_type(mock_repository_list_route: Route) -> None:
@@ -212,6 +227,22 @@ def test_repository_get_with_repository_id_dict(mock_repository_get_route: Route
     assert result.exit_code == 0
     assert "{" in result.output
     assert "'re3data.orgIdentifier': 'r3d100010468'," in result.output
+
+
+def test_repository_get_with_repository_id_csv(mock_repository_get_route: Route, zenodo_id: str) -> None:
+    result = runner.invoke(app, ["repository", "get", zenodo_id, "--return-type", "csv"])
+    assert result.exit_code == 0
+    assert result.exit_code == 0
+    assert "re3data.orgIdentifier,additionalName,repositoryURL," in result.output
+    assert "r3d100010468" in result.output
+
+
+def test_repository_get_with_repository_id_dataframe(mock_repository_get_route: Route, zenodo_id: str) -> None:
+    result = runner.invoke(app, ["repository", "get", zenodo_id, "--return-type", "dataframe"])
+    assert result.exit_code == 0
+    assert "re3data.orgIdentifier" in result.output
+    assert "r3d100010468" in result.output
+    assert "[1 rows x 43 columns]" in result.output
 
 
 def test_repository_get_with_repository_id_response(mock_repository_get_route: Route, zenodo_id: str) -> None:

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 import pytest
+from pandas import DataFrame
 
 from re3data import RepositoryNotFoundError, Response, ReturnType
 from re3data._resources import Repository, RepositoryName, RepositorySummary
@@ -62,6 +63,21 @@ def test_client_list_repositories_dict(client: Client, mock_repository_list_rout
     repository = response[0]
     assert isinstance(repository, dict)
     assert repository["id"] == "r3d100010371"
+
+
+def test_client_list_repositories_csv(client: Client, mock_repository_list_route: Route) -> None:
+    response = client.repositories.list(return_type=ReturnType.CSV)
+    assert isinstance(response, str)
+    assert response.startswith("id,doi,name,")
+    assert "r3d100010371" in response
+    assert "https://doi.org/10.17616/R3P594" in response
+
+
+def test_client_list_repositories_dataframe(client: Client, mock_repository_list_route: Route) -> None:
+    response = client.repositories.list(return_type=ReturnType.DATAFRAME)
+    assert isinstance(response, DataFrame)
+    assert response.shape == (3, 5)
+    assert response["id"].loc[0] == "r3d100010371"
 
 
 def test_client_list_repositories_response(client: Client, mock_repository_list_route: Route) -> None:
@@ -129,6 +145,22 @@ def test_client_get_single_repository_dict(client: Client, mock_repository_get_r
     response = client.repositories.get(zenodo_id, return_type=ReturnType.DICT)
     assert isinstance(response, dict)
     assert response["re3data.orgIdentifier"] == zenodo_id
+
+
+def test_client_get_single_repository_csv(client: Client, mock_repository_get_route: Route, zenodo_id: str) -> None:
+    response = client.repositories.get(zenodo_id, return_type=ReturnType.CSV)
+    assert isinstance(response, str)
+    assert response.startswith("re3data.orgIdentifier,additionalName,repositoryURL,")
+    assert "r3d100010468" in response
+
+
+def test_client_get_single_repository_dataframe(
+    client: Client, mock_repository_get_route: Route, zenodo_id: str
+) -> None:
+    response = client.repositories.get(zenodo_id, return_type=ReturnType.DATAFRAME)
+    assert isinstance(response, DataFrame)
+    assert response.shape == (1, 43)
+    assert response["re3data.orgIdentifier"].loc[0] == "r3d100010468"
 
 
 def test_client_get_single_repository_response(


### PR DESCRIPTION
Fixes #124

## Tasks

- [x] add pandas to optional dependencies
- [x] add return type csv (str)
- [x] add return type dataframe (pandas.DataFrame)
- [x] add pandas to dependencies list in docs
- [x] add return types to readme
- [x] rebase branch
- [x] deal with pandas in type hinter, which results in error
- [x] handle missing import of optional dependency
- [x] add tests
  - [x] cli
  - [x] client
- [x] mypy passes
  - [x] add DataFrame return type to dispatch function
- [x] squash all the commits
