### PR TITLE
ci: set up dependabot to use `uv` ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
     github-actions:
       patterns:
       - '*'
-- package-ecosystem: pip
+- package-ecosystem: uv
   directory: /
   schedule:
     interval: monthly


### PR DESCRIPTION
Fixes #249

See also https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories