### PR TITLE
ci: set dependabot schedule to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
 - package-ecosystem: docker
   directory: /
   schedule:
-    interval: monthly
+    interval: quarterly
   commit-message:
     prefix: build
     include: scope
@@ -16,7 +16,7 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: monthly
+    interval: quarterly
   commit-message:
     prefix: ci
   labels:
@@ -26,23 +26,3 @@ updates:
     github-actions:
       patterns:
       - '*'
-- package-ecosystem: uv
-  directory: /
-  schedule:
-    interval: monthly
-  versioning-strategy: increase-if-necessary
-  commit-message:
-    prefix: build
-    include: scope
-  labels:
-  - 'type: build'
-  - 'deps: python'
-  groups:
-    docs:
-      patterns:
-      - mike
-      - mkdocs*
-    test:
-      patterns:
-      - pytest*
-      - respx


### PR DESCRIPTION
## Description

This PR sets the Dependabot schedule to quarterly to reduce PR noise. It also removes the uv section. 